### PR TITLE
Add configuration for `cryptSharedLib`

### DIFF
--- a/config/packages/doctrine_mongodb.yaml
+++ b/config/packages/doctrine_mongodb.yaml
@@ -6,6 +6,9 @@ doctrine_mongodb:
             server: '%env(resolve:MONGODB_URI)%'
             options: {}
             autoEncryption:
+                extraOptions:
+                    cryptSharedLibRequired: true
+                    cryptSharedLibPath: '%kernel.project_dir%/bin/lib/mongo_crypt_v1.dylib'
                 kmsProvider:
                     type: local
                     key: '%env(MONGODB_ENCRYPTION_KEY)%'


### PR DESCRIPTION
This option is required when `mongocryptd` is not available in a `$PATH` directory. When 

- Download mongo_crypt: https://www.mongodb.com/try/download/enterprise-advanced/releases
- Documentation: https://www.mongodb.com/docs/v7.0/core/queryable-encryption/reference/shared-library/#std-label-qe-reference-shared-library
- PHP Reference for option autoEncrypt.extraOptions: https://www.php.net/manual/en/mongodb-driver-manager.construct.php#mongodb-driver-manager.construct-autoencryption
- Command to download the library on Mac:
```
curl https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-arm64-enterprise-8.0.13.tgz | tar -xzvf - -C ./bin lib/mongo_crypt_v1.dylib
```